### PR TITLE
Implement repeat, cycle, iterate for lazy Texts

### DIFF
--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -125,7 +125,10 @@ module Data.Text.Lazy
     , mapAccumR
 
     -- ** Generation and unfolding
+    , repeat
     , replicate
+    , cycle
+    , iterate
     , unfoldr
     , unfoldrN
 
@@ -218,7 +221,8 @@ import qualified Data.Text.Unsafe as T
 import qualified Data.Text.Internal.Lazy.Fusion as S
 import Data.Text.Internal.Fusion.Types (PairS(..))
 import Data.Text.Internal.Lazy.Fusion (stream, unstream)
-import Data.Text.Internal.Lazy (Text(..), chunk, empty, foldlChunks, foldrChunks)
+import Data.Text.Internal.Lazy (Text(..), chunk, empty, foldlChunks,
+                                foldrChunks, smallChunkSize)
 import Data.Text.Internal (firstf, safe, text)
 import qualified Data.Text.Internal.Functions as F
 import Data.Text.Internal.Lazy.Search (indices)
@@ -918,6 +922,12 @@ mapAccumR f = go
     go z Empty          = (z, Empty)
 {-# INLINE mapAccumR #-}
 
+-- | @'repeat' x@ is an infinite 'Text', with @x@ the value of every
+-- element.
+repeat :: Char -> Text
+repeat c = let t = Chunk (T.replicate smallChunkSize (T.singleton c)) t
+            in t
+
 -- | /O(n*m)/ 'replicate' @n@ @t@ is a 'Text' consisting of the input
 -- @t@ repeated @n@ times.
 replicate :: Int64 -> Text -> Text
@@ -928,6 +938,21 @@ replicate n t
     where rep !i | i >= n    = []
                  | otherwise = t : rep (i+1)
 {-# INLINE [1] replicate #-}
+
+-- | 'cycle' ties a finite 'Text' into a circular one, or equivalently,
+-- the infinite repetition of the original 'Text'.
+cycle :: Text -> Text
+cycle Empty = emptyError "cycle"
+cycle t     = let t' = foldrChunks Chunk t' t
+               in t'
+
+-- | @'iterate' f x@ returns an infinite 'Text' of repeated applications
+-- of @f@ to @x@:
+-- 
+-- > iterate f x == [x, f x, f (f x), ...]
+iterate :: (Char -> Char) -> Char -> Text
+iterate f = unfoldr $ \x -> case f x of
+                                 !x' -> Just (x', x')
 
 -- | /O(n)/ 'replicateChar' @n@ @c@ is a 'Text' of length @n@ with @c@ the
 -- value of every element. Subject to fusion.

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -939,8 +939,8 @@ replicate n t
                  | otherwise = t : rep (i+1)
 {-# INLINE [1] replicate #-}
 
--- | 'cycle' ties a finite 'Text' into a circular one, or equivalently,
--- the infinite repetition of the original 'Text'.
+-- | 'cycle' ties a finite, non-empty 'Text' into a circular one, or
+-- equivalently, the infinite repetition of the original 'Text'.
 cycle :: Text -> Text
 cycle Empty = emptyError "cycle"
 cycle t     = let t' = foldrChunks Chunk t' t
@@ -951,8 +951,8 @@ cycle t     = let t' = foldrChunks Chunk t' t
 -- 
 -- > iterate f x == [x, f x, f (f x), ...]
 iterate :: (Char -> Char) -> Char -> Text
-iterate f = unfoldr $ \x -> case f x of
-                                 !x' -> Just (x', x')
+iterate f c = let t c' = Chunk (T.singleton c') (t (f c'))
+               in t c
 
 -- | /O(n)/ 'replicateChar' @n@ @c@ is a 'Text' of length @n@ with @c@ the
 -- value of every element. Subject to fusion.

--- a/tests/Tests/Properties.hs
+++ b/tests/Tests/Properties.hs
@@ -440,6 +440,10 @@ t_mapAccumR f z   = L.mapAccumR f z `eqP` (second unpackS . T.mapAccumR f z)
 tl_mapAccumR f z  = L.mapAccumR f z `eqP` (second unpackS . TL.mapAccumR f z)
     where _types  = f :: Int -> Char -> (Int,Char)
 
+tl_repeat n       = (L.take m . L.repeat) `eq`
+                    (unpackS . TL.take (fromIntegral m) . TL.repeat)
+    where m = fromIntegral (n :: Word8)
+
 replicate n l = concat (L.replicate n l)
 
 s_replicate n     = replicate m `eq`
@@ -449,6 +453,14 @@ t_replicate n     = replicate m `eq` (unpackS . T.replicate m . packS)
     where m = fromIntegral (n :: Word8)
 tl_replicate n    = replicate m `eq`
                     (unpackS . TL.replicate (fromIntegral m) . packS)
+    where m = fromIntegral (n :: Word8)
+
+tl_cycle n        = (L.take m . L.cycle) `eq`
+                    (unpackS . TL.take (fromIntegral m) . TL.cycle . packS)
+    where m = fromIntegral (n :: Word8)
+
+tl_iterate f n    = (L.take m . L.iterate f) `eq`
+                    (unpackS . TL.take (fromIntegral m) . TL.iterate f)
     where m = fromIntegral (n :: Word8)
 
 unf :: Int -> Char -> Maybe (Char, Char)
@@ -1094,9 +1106,12 @@ tests =
       ],
 
       testGroup "unfolds" [
+        testProperty "tl_repeat" tl_repeat,
         testProperty "s_replicate" s_replicate,
         testProperty "t_replicate" t_replicate,
         testProperty "tl_replicate" tl_replicate,
+        testProperty "tl_cycle" tl_cycle,
+        testProperty "tl_iterate" tl_iterate,
         testProperty "t_unfoldr" t_unfoldr,
         testProperty "tl_unfoldr" tl_unfoldr,
         testProperty "t_unfoldrN" t_unfoldrN,


### PR DESCRIPTION
In which I attempt to define `repeat`, `cycle`, and `iterate` similarly to how [lazy `ByteString`](http://hackage.haskell.org/package/bytestring-0.10.4.1/docs/Data-ByteString-Lazy.html#g:10) does. I have no idea if this can be fused or inlined more, so I will leave that to someone with more knowledge of high-performance Haskell than me.