### PR TITLE
Show: Activate literal rewrite rules in simplifier phase 1

### DIFF
--- a/Data/Text/Show.hs
+++ b/Data/Text/Show.hs
@@ -50,19 +50,19 @@ unpackCString# :: Addr# -> Text
 unpackCString# addr# = unstream (S.streamCString# addr#)
 {-# NOINLINE unpackCString# #-}
 
-{-# RULES "TEXT literal" [2] forall a.
+{-# RULES "TEXT literal" [1] forall a.
     unstream (S.map safe (S.streamList (GHC.unpackCString# a)))
       = unpackCString# a #-}
 
-{-# RULES "TEXT literal UTF8" [2] forall a.
+{-# RULES "TEXT literal UTF8" [1] forall a.
     unstream (S.map safe (S.streamList (GHC.unpackCStringUtf8# a)))
       = unpackCString# a #-}
 
-{-# RULES "TEXT empty literal" [2]
+{-# RULES "TEXT empty literal" [1]
     unstream (S.map safe (S.streamList []))
       = empty_ #-}
 
-{-# RULES "TEXT singleton literal" [2] forall a.
+{-# RULES "TEXT singleton literal" [1] forall a.
     unstream (S.map safe (S.streamList [a]))
       = singleton_ a #-}
 

--- a/Data/Text/Show.hs
+++ b/Data/Text/Show.hs
@@ -50,19 +50,19 @@ unpackCString# :: Addr# -> Text
 unpackCString# addr# = unstream (S.streamCString# addr#)
 {-# NOINLINE unpackCString# #-}
 
-{-# RULES "TEXT literal" forall a.
+{-# RULES "TEXT literal" [2] forall a.
     unstream (S.map safe (S.streamList (GHC.unpackCString# a)))
       = unpackCString# a #-}
 
-{-# RULES "TEXT literal UTF8" forall a.
+{-# RULES "TEXT literal UTF8" [2] forall a.
     unstream (S.map safe (S.streamList (GHC.unpackCStringUtf8# a)))
       = unpackCString# a #-}
 
-{-# RULES "TEXT empty literal"
+{-# RULES "TEXT empty literal" [2]
     unstream (S.map safe (S.streamList []))
       = empty_ #-}
 
-{-# RULES "TEXT singleton literal" forall a.
+{-# RULES "TEXT singleton literal" [2] forall a.
     unstream (S.map safe (S.streamList [a]))
       = singleton_ a #-}
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.2.1.2
+
+* Bug fix: Run literal rewrite rules in simplifier phase 2.
+  The behavior of the simplifier changed in GHC 7.10.2,
+  causing these rules to fail to fire, leading to poor code generation
+  and long compilation times. See
+  [GHC Trac #10528](https://ghc.haskell.org/trac/ghc/ticket/10528).
+
 1.2.1.1
 
 * Expose unpackCString#, which you should never use.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+1.2.1.3
+
+* Bug fix: As it turns out, moving the literal rewrite rules to simplifier 
+  phase 2 does not prevent competition with the `unpack` rule, which is
+  also active in this phase. Unfortunately this was hidden due to a silly
+  test environment mistake. Moving literal rules back to phase 1 finally
+  fixes GHC Trac #10528 correctly.
+
 1.2.1.2
 
 * Bug fix: Run literal rewrite rules in simplifier phase 2.

--- a/tests/LiteralRuleTest.hs
+++ b/tests/LiteralRuleTest.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LiteralRuleTest where
+
+import Data.Text (Text)
+
+-- This should produce 8 firings of the "TEXT literal" rule
+strings :: [Text]
+strings = [ "abstime", "aclitem", "bit", "bool", "box", "bpchar", "bytea", "char" ]
+
+-- This should produce 7 firings of the "TEXT literal UTF8" rule
+utf8Strings :: [Text]
+utf8Strings = [ "\0abstime", "\0aclitem", "\xfefe bit", "\0bool", "\0box", "\0bpchar", "\0bytea" ]
+
+-- This should produce 4 firings of the "TEXT empty literal" rule
+empties :: [Text]
+empties = [ "", "", "", "" ]
+
+-- This should produce 5 firings of the "TEXT empty literal" rule
+--singletons :: [Text]
+--singletons = [ "a", "b", "c", "d", "e" ]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,10 @@
 count = 1000
 
+all: coverage literal-rule-test
+
+literal-rule-test:
+	./literal-rule-test.sh
+
 coverage: build coverage/hpc_index.html
 
 build: text-test-data
@@ -32,4 +37,4 @@ coverage/hpc_index.html: coverage/coverage.tix
 clean:
 	rm -rf dist coverage .hpc
 
-.PHONY: build coverage
+.PHONY: build coverage all literal-rule-test

--- a/tests/literal-rule-test.sh
+++ b/tests/literal-rule-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+failed=0
+
+function check_firings() {
+    rule=$1
+    expected=$2
+    build="ghc -O -ddump-rule-firings LiteralRuleTest.hs"
+    build="$build -i.. -I../include -DMIN_VERSION_bytestring(a,b,c)=1"
+    touch LiteralRuleTest.hs
+    echo -n "Want to see $expected firings of rule $rule... " >&2
+    firings=$($build 2>&1 | grep "Rule fired: $rule\$" | wc -l)
+    rm -f LiteralRuleTest.{o.hi}
+
+    if [ $firings != $expected ]; then
+        echo "failed, saw $firings" >&2
+        failed=1
+    else
+        echo "pass" >&2
+    fi
+}
+
+check_firings "TEXT literal" 8
+check_firings "TEXT literal UTF8" 7
+check_firings "TEXT empty literal" 4
+# This is broken at the moment. "TEXT literal" rule fires instead.
+#check_firings "TEXT singleton literal" 5
+
+exit $failed

--- a/text.cabal
+++ b/text.cabal
@@ -1,5 +1,5 @@
 name:           text
-version:        1.2.1.1
+version:        1.2.1.2
 homepage:       https://github.com/bos/text
 bug-reports:    https://github.com/bos/text/issues
 synopsis:       An efficient packed Unicode text type.

--- a/text.cabal
+++ b/text.cabal
@@ -1,5 +1,5 @@
 name:           text
-version:        1.2.1.2
+version:        1.2.1.3
 homepage:       https://github.com/bos/text
 bug-reports:    https://github.com/bos/text/issues
 synopsis:       An efficient packed Unicode text type.


### PR DESCRIPTION
Previously these rewrite rules were quite fragile as they could compete with the `unpack` rule defined in `GHC.Base`. This was tickled by 7.10.2, which happened to rewrite the LHS of rules with other rules (which is itself a bug in GHC). This caused the literal rules to fail to fire, which then resulted in long compilation times and poor code generation.

Unfortunately it took a couple of attempts to get this right. The first attempt moved the rules forward in compilation to phase 2; this did not resolve the issue but this fact was hidden by a silly testing mistake. I then added a proper test of the literal rules to prevent future mistakes and found that moving the rules to simplifier phase 1 resolved the issue. 

See [GHC Trac #10528](https://ghc.haskell.org/trac/ghc/ticket/10528) for further discussion.
