### PR TITLE
Add `PrintfArg` instances for `Text` (strict and lazy).

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -237,6 +237,7 @@ import Data.Int (Int64)
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
 #endif
+import Text.Printf (PrintfArg, formatArg, formatString)
 
 -- $strict
 --
@@ -370,6 +371,9 @@ instance Data Text where
     1 -> k (z pack)
     _ -> P.error "gunfold"
   dataTypeOf _ = textDataType
+
+instance PrintfArg Text where
+  formatArg txt = formatString $ unpack txt
 
 packConstr :: Constr
 packConstr = mkConstr textDataType "pack" [] Prefix

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -237,6 +237,7 @@ import qualified GHC.Base as GHC
 import qualified GHC.Exts as Exts
 #endif
 import GHC.Prim (Addr#)
+import Text.Printf (PrintfArg, formatArg, formatString)
 
 -- $fusion
 --
@@ -371,6 +372,9 @@ instance Data Text where
     1 -> k (z pack)
     _ -> error "Data.Text.Lazy.Text.gunfold"
   dataTypeOf _   = textDataType
+
+instance PrintfArg Text where
+  formatArg txt = formatString $ unpack txt
 
 packConstr :: Constr
 packConstr = mkConstr textDataType "pack" [] Prefix


### PR DESCRIPTION
Hi,

I would like to add instances for `PrintfArg`, I need them and that seems quite useful to have it directly in the library.

I'm not sure if those instances should be guarded behind a conditional checking on GHC version?

Let me know what you think

Thanks in advance