### PR TITLE
Implement takeWhileEnd

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -129,6 +129,7 @@ module Data.Text
     , drop
     , dropEnd
     , takeWhile
+    , takeWhileEnd
     , dropWhile
     , dropWhileEnd
     , dropAround
@@ -1122,6 +1123,27 @@ takeWhile p t@(Text arr off len) = loop 0
     takeWhile p t = unstream (S.takeWhile p (stream t))
 "TEXT takeWhile -> unfused" [1] forall p t.
     unstream (S.takeWhile p (stream t)) = takeWhile p t
+  #-}
+
+-- | /O(n)/ 'takeWhileEnd', applied to a predicate @p@ and a 'Text',
+-- returns the longest suffix (possibly empty) of elements that
+-- satisfy @p@.  Subject to fusion.
+-- Examples:
+--
+-- > takeWhileEnd (=='o') "foo" == "oo"
+takeWhileEnd :: (Char -> Bool) -> Text -> Text
+takeWhileEnd p t@(Text arr off len) = loop (len-1) len
+  where loop !i !l | l <= 0    = t
+                   | p c       = loop (i+d) (l+d)
+                   | otherwise = text arr (off+l) (len-l)
+            where (c,d)        = reverseIter t i
+{-# INLINE [1] takeWhileEnd #-}
+
+{-# RULES
+"TEXT takeWhileEnd -> fused" [~1] forall p t.
+    takeWhileEnd p t = S.reverse (S.takeWhile p (S.reverseStream t))
+"TEXT takeWhileEnd -> unfused" [1] forall p t.
+    S.reverse (S.takeWhile p (S.reverseStream t)) = takeWhileEnd p t
   #-}
 
 -- | /O(n)/ 'dropWhile' @p@ @t@ returns the suffix remaining after

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -140,6 +140,7 @@ module Data.Text.Lazy
     , drop
     , dropEnd
     , takeWhile
+    , takeWhileEnd
     , dropWhile
     , dropWhileEnd
     , dropAround
@@ -1119,6 +1120,20 @@ takeWhile p t0 = takeWhile' t0
 "LAZY TEXT takeWhile -> unfused" [1] forall p t.
     unstream (S.takeWhile p (stream t)) = takeWhile p t
   #-}
+-- | /O(n)/ 'takeWhileEnd', applied to a predicate @p@ and a 'Text',
+-- returns the longest suffix (possibly empty) of elements that
+-- satisfy @p@.
+-- Examples:
+--
+-- > takeWhileEnd (=='o') "foo" == "oo"
+takeWhileEnd :: (Char -> Bool) -> Text -> Text
+takeWhileEnd p = takeChunk empty . L.reverse . toChunks
+  where takeChunk acc []     = acc
+        takeChunk acc (t:ts) = if T.length t' < T.length t
+                               then (Chunk t' acc)
+                               else takeChunk (Chunk t' acc) ts
+          where t' = T.takeWhileEnd p t
+{-# INLINE takeWhileEnd #-}
 
 -- | /O(n)/ 'dropWhile' @p@ @t@ returns the suffix remaining after
 -- 'takeWhile' @p@ @t@.  Subject to fusion.

--- a/tests/Tests/Properties.hs
+++ b/tests/Tests/Properties.hs
@@ -516,6 +516,10 @@ sf_takeWhile q p  = (L.takeWhile p . L.filter q) `eqP`
                     (unpackS . S.takeWhile p . S.filter q)
 t_takeWhile p     = L.takeWhile p `eqP` (unpackS . T.takeWhile p)
 tl_takeWhile p    = L.takeWhile p `eqP` (unpackS . TL.takeWhile p)
+t_takeWhileEnd p  = (L.reverse . L.takeWhile p . L.reverse) `eqP`
+                    (unpackS . T.takeWhileEnd p)
+tl_takeWhileEnd p = (L.reverse . L.takeWhile p . L.reverse) `eqP`
+                    (unpackS . TL.takeWhileEnd p)
 s_dropWhile p     = L.dropWhile p `eqP` (unpackS . S.dropWhile p)
 s_dropWhile_s p   = L.dropWhile p `eqP` (unpackS . S.unstream . S.dropWhile p)
 sf_dropWhile q p  = (L.dropWhile p . L.filter q) `eqP`
@@ -1142,6 +1146,8 @@ tests =
         testProperty "sf_takeWhile" sf_takeWhile,
         testProperty "t_takeWhile" t_takeWhile,
         testProperty "tl_takeWhile" tl_takeWhile,
+        testProperty "t_takeWhileEnd" t_takeWhileEnd,
+        testProperty "tl_takeWhileEnd" tl_takeWhileEnd,
         testProperty "sf_dropWhile" sf_dropWhile,
         testProperty "s_dropWhile" s_dropWhile,
         testProperty "s_dropWhile_s" s_dropWhile_s,


### PR DESCRIPTION
This commit adds a `takeWhileEnd` function, both for strict and lazy Text, closing #89.
Appropriate QuickCheck tests are also added.

I’ve stick as much as possible to the style of the existing `takeWhile` / `dropWhileEnd` / etc.

I am no low-level Haskell expert though, and they are a couple of things I dumbly copy without fully
understanding what they do:

- in Lazy.hs, I use `{-# INLINE takeWhileEnd #-}` and not `{-# INLINE [1] takeWhileEnd #-}`.
This is similar to the existing `{-# INLINE dropWhileEnd #-}` but unlike most inline declarations which use the `[1]`; I don’t know what is the correct declaration to use here.
- in Text.hs, I have added `{-# RULES …}` by mere copy/pasting; I don’t fully understand this RULES thing.
- in Lazy.hs, I did NOT add `{-# RULES …}` because `dropWhileEnd` don’t have them. I’m not sure if lazy `takeWhileEnd` could have RULES, unlike `dropWhileEnd`, or not. I don’t understand if `dropWhileEnd` don’t have RULES because none are applicable for it or if they are just missing.