### PR TITLE
Prepare `text` for GHC HEAD/8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 cabal-dev
+cabal.sandbox.config

--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -214,6 +214,9 @@ import qualified Data.Text.Array as A
 import qualified Data.List as L
 import Data.Binary (Binary(get, put))
 import Data.Monoid (Monoid(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.String (IsString(..))
 import qualified Data.Text.Internal.Fusion as S
 import qualified Data.Text.Internal.Fusion.Common as S
@@ -326,9 +329,21 @@ instance Ord Text where
 instance Read Text where
     readsPrec p str = [(pack x,y) | (x,y) <- readsPrec p str]
 
+#if MIN_VERSION_base(4,9,0)
+-- Semigroup orphan instances for older GHCs are provided by
+-- 'semigroups` package
+
+instance Semigroup Text where
+    (<>) = append
+#endif
+
 instance Monoid Text where
     mempty  = empty
+#if MIN_VERSION_base(4,9,0)
+    mappend = (<>) -- future-proof definition
+#else
     mappend = append
+#endif
     mconcat = concat
 
 instance IsString Text where

--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -240,7 +240,9 @@ import Data.Int (Int64)
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
 #endif
+#if MIN_VERSION_base(4,7,0)
 import Text.Printf (PrintfArg, formatArg, formatString)
+#endif
 
 -- $strict
 --
@@ -387,8 +389,11 @@ instance Data Text where
     _ -> P.error "gunfold"
   dataTypeOf _ = textDataType
 
+#if MIN_VERSION_base(4,7,0)
+-- | Only defined for @base-4.7.0.0@ and later
 instance PrintfArg Text where
   formatArg txt = formatString $ unpack txt
+#endif
 
 packConstr :: Constr
 packConstr = mkConstr textDataType "pack" [] Prefix

--- a/Data/Text/Encoding/Error.hs
+++ b/Data/Text/Encoding/Error.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 -- |

--- a/Data/Text/Internal/Builder.hs
+++ b/Data/Text/Internal/Builder.hs
@@ -94,7 +94,7 @@ instance Monoid Builder where
    {-# INLINE mempty #-}
    mappend = append
    {-# INLINE mappend #-}
-   mconcat = foldr mappend mempty
+   mconcat = foldr mappend Data.Monoid.mempty
    {-# INLINE mconcat #-}
 
 instance String.IsString Builder where

--- a/Data/Text/Internal/Builder.hs
+++ b/Data/Text/Internal/Builder.hs
@@ -59,6 +59,9 @@ module Data.Text.Internal.Builder
 
 import Control.Monad.ST (ST, runST)
 import Data.Monoid (Monoid(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.Text.Internal (Text(..))
 import Data.Text.Internal.Lazy (smallChunkSize)
 import Data.Text.Unsafe (inlineInterleaveST)
@@ -89,10 +92,20 @@ newtype Builder = Builder {
                 -> ST s [S.Text]
    }
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup Builder where
+   (<>) = append
+   {-# INLINE (<>) #-}
+#endif
+
 instance Monoid Builder where
    mempty  = empty
    {-# INLINE mempty #-}
+#if MIN_VERSION_base(4,9,0)
+   mappend = (<>) -- future-proof definition
+#else
    mappend = append
+#endif
    {-# INLINE mappend #-}
    mconcat = foldr mappend Data.Monoid.mempty
    {-# INLINE mconcat #-}

--- a/Data/Text/Internal/Builder/Functions.hs
+++ b/Data/Text/Internal/Builder/Functions.hs
@@ -23,7 +23,8 @@ module Data.Text.Internal.Builder.Functions
 
 import Data.Monoid (mappend)
 import Data.Text.Lazy.Builder (Builder)
-import GHC.Base
+import GHC.Base (chr#,ord#,(+#),Int(I#),Char(C#))
+import Prelude ()
 
 -- | Unsafe conversion for decimal digits.
 {-# INLINE i2d #-}

--- a/Data/Text/Internal/Read.hs
+++ b/Data/Text/Internal/Read.hs
@@ -18,7 +18,7 @@ module Data.Text.Internal.Read
     , perhaps
     ) where
 
-import Control.Applicative (Applicative(..))
+import Control.Applicative as App (Applicative(..))
 import Control.Arrow (first)
 import Control.Monad (ap)
 import Data.Char (ord)
@@ -38,7 +38,7 @@ instance Applicative (IParser t) where
     (<*>) = ap
 
 instance Monad (IParser t) where
-    return = pure
+    return = App.pure
     m >>= k  = P $ \t -> case runP m t of
                            Left err     -> Left err
                            Right (a,t') -> runP (k a) t'

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -240,7 +240,9 @@ import qualified GHC.Base as GHC
 import qualified GHC.Exts as Exts
 #endif
 import GHC.Prim (Addr#)
+#if MIN_VERSION_base(4,7,0)
 import Text.Printf (PrintfArg, formatArg, formatString)
+#endif
 
 -- $fusion
 --
@@ -388,8 +390,11 @@ instance Data Text where
     _ -> error "Data.Text.Lazy.Text.gunfold"
   dataTypeOf _   = textDataType
 
+#if MIN_VERSION_base(4,7,0)
+-- | Only defined for @base-4.7.0.0@ and later
 instance PrintfArg Text where
   formatArg txt = formatString $ unpack txt
+#endif
 
 packConstr :: Constr
 packConstr = mkConstr textDataType "pack" [] Prefix

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -214,6 +214,9 @@ import Data.Data (Data(gfoldl, toConstr, gunfold, dataTypeOf), constrIndex,
                   Constr, mkConstr, DataType, mkDataType, Fixity(Prefix))
 import Data.Binary (Binary(get, put))
 import Data.Monoid (Monoid(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (Semigroup(..))
+#endif
 import Data.String (IsString(..))
 import qualified Data.Text as T
 import qualified Data.Text.Internal as T
@@ -335,9 +338,21 @@ instance Show Text where
 instance Read Text where
     readsPrec p str = [(pack x,y) | (x,y) <- readsPrec p str]
 
+#if MIN_VERSION_base(4,9,0)
+-- Semigroup orphan instances for older GHCs are provided by
+-- 'semigroups` package
+
+instance Semigroup Text where
+    (<>) = append
+#endif
+
 instance Monoid Text where
     mempty  = empty
+#if MIN_VERSION_base(4,9,0)
+    mappend = (<>) -- future-proof definition
+#else
     mappend = append
+#endif
     mconcat = concat
 
 instance IsString Text where

--- a/Data/Text/Lazy/Builder/Int.hs
+++ b/Data/Text/Lazy/Builder/Int.hs
@@ -35,7 +35,7 @@ import Control.Monad.ST
 
 #ifdef  __GLASGOW_HASKELL__
 # if defined(INTEGER_GMP)
-import GHC.Integer.GMP.Internals
+import GHC.Integer.GMP.Internals (Integer(S#))
 # elif defined(INTEGER_SIMPLE)
 import GHC.Integer
 # else
@@ -55,7 +55,7 @@ decimal :: Integral a => a -> Builder
 {-# RULES "decimal/Int16" decimal = boundedDecimal :: Int16 -> Builder #-}
 {-# RULES "decimal/Int32" decimal = boundedDecimal :: Int32 -> Builder #-}
 {-# RULES "decimal/Int64" decimal = boundedDecimal :: Int64 -> Builder #-}
-{-# RULES "decimal/Word" decimal = positive :: Word -> Builder #-}
+{-# RULES "decimal/Word" decimal = positive :: Data.Word.Word -> Builder #-}
 {-# RULES "decimal/Word8" decimal = positive :: Word8 -> Builder #-}
 {-# RULES "decimal/Word16" decimal = positive :: Word16 -> Builder #-}
 {-# RULES "decimal/Word32" decimal = positive :: Word32 -> Builder #-}
@@ -247,7 +247,7 @@ integer base i
                     PAIR(x,y) -> pblock q <> pblock r <> putB ns
                         where q = fromInteger x
                               r = fromInteger y
-    putB _ = mempty
+    putB _ = Data.Monoid.mempty
 
     int :: Int -> Builder
     int x | base == 10 = decimal x

--- a/Data/Text/Lazy/Encoding.hs
+++ b/Data/Text/Lazy/Encoding.hs
@@ -62,7 +62,7 @@ import qualified Data.ByteString.Lazy.Internal as B
 import qualified Data.ByteString.Unsafe as B
 #if MIN_VERSION_bytestring(0,10,4)
 import Data.Word (Word8)
-import Data.Monoid (mappend, mempty)
+import Data.Monoid (Monoid(..))
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Builder.Extra as B (safeStrategy, toLazyByteStringWith)
 import qualified Data.ByteString.Builder.Prim as BP
@@ -161,7 +161,7 @@ encodeUtf8 lt@(Chunk t _) =
 
 encodeUtf8Builder :: Text -> B.Builder
 encodeUtf8Builder =
-    foldrChunks (\c b -> TE.encodeUtf8Builder c `mappend` b) mempty
+    foldrChunks (\c b -> TE.encodeUtf8Builder c `mappend` b) Data.Monoid.mempty
 
 {-# INLINE encodeUtf8BuilderEscaped #-}
 encodeUtf8BuilderEscaped :: BP.BoundedPrim Word8 -> Text -> B.Builder

--- a/Data/Text/Lazy/Read.hs
+++ b/Data/Text/Lazy/Read.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings, CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
 

--- a/Data/Text/Lazy/Read.hs
+++ b/Data/Text/Lazy/Read.hs
@@ -56,7 +56,7 @@ decimal :: Integral a => Reader a
 {-# SPECIALIZE decimal :: Reader Int32 #-}
 {-# SPECIALIZE decimal :: Reader Int64 #-}
 {-# SPECIALIZE decimal :: Reader Integer #-}
-{-# SPECIALIZE decimal :: Reader Word #-}
+{-# SPECIALIZE decimal :: Reader Data.Word.Word #-}
 {-# SPECIALIZE decimal :: Reader Word8 #-}
 {-# SPECIALIZE decimal :: Reader Word16 #-}
 {-# SPECIALIZE decimal :: Reader Word32 #-}

--- a/Data/Text/Read.hs
+++ b/Data/Text/Read.hs
@@ -55,7 +55,7 @@ decimal :: Integral a => Reader a
 {-# SPECIALIZE decimal :: Reader Int32 #-}
 {-# SPECIALIZE decimal :: Reader Int64 #-}
 {-# SPECIALIZE decimal :: Reader Integer #-}
-{-# SPECIALIZE decimal :: Reader Word #-}
+{-# SPECIALIZE decimal :: Reader Data.Word.Word #-}
 {-# SPECIALIZE decimal :: Reader Word8 #-}
 {-# SPECIALIZE decimal :: Reader Word16 #-}
 {-# SPECIALIZE decimal :: Reader Word32 #-}


### PR DESCRIPTION
This removes several warnings in `text`, fixes breakage with GHC<7.8, and prepares `text` for GHC HEAD/base-4.9 by defining `Semigroup` instances.

Specifically, `text` is warning free with the following settings:

 - `cabal configure -w /opt/ghc/head/bin/ghc --ghc-options='-Wall -Wcompat -Wno-inline-rule-shadowing -Werror'`
 - `cabal configure -w /opt/ghc/7.10.3/bin/ghc --ghc-options='-Wall -Werror'`
 - `cabal configure -w /opt/ghc/7.8.4/bin/ghc --ghc-options='-Wall -Werror'`
 - `cabal configure -w /opt/ghc/7.6.3/bin/ghc --ghc-options='-Wall -Werror'`
 - `cabal configure -w /opt/ghc/7.4.2/bin/ghc --ghc-options='-Wall -Werror'`

GHC 7.2 and GHC 7.0 still have warnings about FFI & CType newtypes


