### PR TITLE
[WIP] Various rule-robustness issues

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -238,6 +238,7 @@ import Data.ByteString (ByteString)
 import qualified Data.Text.Lazy as L
 import Data.Int (Int64)
 #endif
+import GHC.Base (eqInt, neInt, gtInt, geInt, ltInt, leInt)
 #if __GLASGOW_HASKELL__ >= 708
 import qualified GHC.Exts as Exts
 #endif
@@ -592,32 +593,32 @@ compareLength t n = S.compareLengthI (stream t) n
 
 {-# RULES
 "TEXT ==N/length -> compareLength/==EQ" [~1] forall t n.
-    (==) (length t) n = compareLength t n == EQ
+    eqInt (length t) n = compareLength t n == EQ
   #-}
 
 {-# RULES
 "TEXT /=N/length -> compareLength//=EQ" [~1] forall t n.
-    (/=) (length t) n = compareLength t n /= EQ
+    neInt (length t) n = compareLength t n /= EQ
   #-}
 
 {-# RULES
 "TEXT <N/length -> compareLength/==LT" [~1] forall t n.
-    (<) (length t) n = compareLength t n == LT
+    ltInt (length t) n = compareLength t n == LT
   #-}
 
 {-# RULES
 "TEXT <=N/length -> compareLength//=GT" [~1] forall t n.
-    (<=) (length t) n = compareLength t n /= GT
+    leInt (length t) n = compareLength t n /= GT
   #-}
 
 {-# RULES
 "TEXT >N/length -> compareLength/==GT" [~1] forall t n.
-    (>) (length t) n = compareLength t n == GT
+    gtInt (length t) n = compareLength t n == GT
   #-}
 
 {-# RULES
 "TEXT >=N/length -> compareLength//=LT" [~1] forall t n.
-    (>=) (length t) n = compareLength t n /= LT
+    geInt (length t) n = compareLength t n /= LT
   #-}
 
 -- -----------------------------------------------------------------------------

--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -571,7 +571,9 @@ isSingleton = S.isSingleton . stream
 -- Subject to fusion.
 length :: Text -> Int
 length t = S.length (stream t)
-{-# INLINE length #-}
+{-# INLINE [0] length #-}
+-- length needs to be phased after the compareN/length rules otherwise
+-- it may inline before the rules have an opportunity to fire.
 
 -- | /O(n)/ Compare the count of characters in a 'Text' to a number.
 -- Subject to fusion.

--- a/Data/Text/Internal/Builder.hs
+++ b/Data/Text/Internal/Builder.hs
@@ -242,6 +242,8 @@ flush = Builder $ \ k buf@(Buffer p o u l) ->
                 !t = Text arr o u
             ts <- inlineInterleaveST (k b)
             return $! t : ts
+{-# INLINE [1] flush #-}
+-- defer inlining so that flush/flush rule may fire.
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
The fragile-rule warnings introduced in GHC 8.0 have pointed out a few more places where the rules in `text` may not fire,

 * `Data.Text.length` may be inlined before the `compareLength` rules have a change to fire
 * the `compareLength` rules match against class ops
 * `Data.Text.Lazy.Builder.Internal.flush` may be inlined before the `flush/flush` rule has a chance to fire

I still need to test this against GHC <8.0 and check for performance regressions.