### PR TITLE
Optimize unstream loop (3x better on micro benchmark)

### DIFF
--- a/Data/Text/Internal/Fusion.hs
+++ b/Data/Text/Internal/Fusion.hs
@@ -98,25 +98,35 @@ reverseStream (Text arr off len) = Stream next (off+len-1) (betweenSize (len `sh
 -- | /O(n)/ Convert a 'Stream Char' into a 'Text'.
 unstream :: Stream Char -> Text
 unstream (Stream next0 s0 len) = runText $ \done -> do
-  let mlen = upperBound 4 len
+  -- Before encoding each char we perform a buffer realloc check assuming
+  -- worst case encoding size of two 16-bit units for the char. Just add an
+  -- extra space to the buffer so that we do not end up reallocating even when
+  -- all the chars are encoded as single unit.
+  let mlen = upperBound 4 len + 1
   arr0 <- A.new mlen
-  let outer arr top = loop
+  let outer !arr !maxi = encode
        where
-        loop !s !i =
-            case next0 s of
-              Done          -> done arr i
-              Skip s'       -> loop s' i
-              Yield x s'
-                | j >= top  -> {-# SCC "unstream/resize" #-} do
-                               let top' = (top + 1) `shiftL` 1
-                               arr' <- A.new top'
-                               A.copyM arr' 0 arr 0 top
-                               outer arr' top' s i
-                | otherwise -> do d <- unsafeWrite arr i x
-                                  loop s' (i+d)
-                where j | ord x < 0x10000 = i
-                        | otherwise       = i + 1
-  outer arr0 mlen s0 0
+        -- keep the common case loop as small as possible
+        encode !si !di =
+            case next0 si of
+                Done        -> done arr di
+                Skip si'    -> encode si' di
+                Yield c si'
+                    -- simply check for the worst case
+                    | maxi < di + 1 -> realloc si di
+                    | otherwise -> do
+                            n <- unsafeWrite arr di c
+                            encode si' (di + n)
+
+        -- keep uncommon case separate from the common case code
+        {-# NOINLINE realloc #-}
+        realloc !si !di = do
+            let newlen = (maxi + 1) * 2
+            arr' <- A.new newlen
+            A.copyM arr' 0 arr 0 di
+            outer arr' (newlen - 1) si di
+
+  outer arr0 (mlen - 1) s0 0
 {-# INLINE [0] unstream #-}
 {-# RULES "STREAM stream/unstream fusion" forall s. stream (unstream s) = s #-}
 

--- a/Data/Text/Internal/Fusion/Common.hs
+++ b/Data/Text/Internal/Fusion/Common.hs
@@ -669,12 +669,12 @@ scanl f z0 (Stream next0 s0 len) = Stream next (Scan1 z0 s0) (len+1) -- HINT may
 -- ** Generating and unfolding streams
 
 replicateCharI :: Integral a => a -> Char -> Stream Char
-replicateCharI n c
+replicateCharI !n !c
     | n < 0     = empty
     | otherwise = Stream next 0 (fromIntegral n) -- HINT maybe too low
   where
-    next i | i >= n    = Done
-           | otherwise = Yield c (i + 1)
+    next !i | i >= n    = Done
+            | otherwise = Yield c (i + 1)
 {-# INLINE [0] replicateCharI #-}
 
 data RI s = RI !s {-# UNPACK #-} !Int64

--- a/benchmarks/haskell/Benchmarks.hs
+++ b/benchmarks/haskell/Benchmarks.hs
@@ -53,7 +53,7 @@ benchmarks = do
         , Mul.benchmark
         , Pure.benchmark "tiny" (tf "tiny.txt")
         , Pure.benchmark "ascii" (tf "ascii-small.txt")
-        , Pure.benchmark "france" (tf "france.html")
+        -- , Pure.benchmark "france" (tf "france.html")
         , Pure.benchmark "russian" (tf "russian-small.txt")
         , Pure.benchmark "japanese" (tf "japanese.txt")
         , ReadNumbers.benchmark (tf "numbers.txt")


### PR DESCRIPTION
Affected macro benchmarks' improvement range from 2%  to 34%. More details are available in the commit message. 

I have also added corresponding micro benchmarks. Also added strictness annotation for `replicateCharI` args.

This change was motivated by a perf measurement for pure Haskell unicode normalization code that I am working on. While comparing the performance with text-icu normalization I found that just stream/unstream with no other processing in between was taking more time than what text-icu was taking for normalizing English text. Now, with this change stream/unstream is performing better than that.