### PR TITLE
Depend on bytestring-builder for API backwards compatibility

### DIFF
--- a/Data/Text/Encoding.hs
+++ b/Data/Text/Encoding.hs
@@ -55,13 +55,9 @@ module Data.Text.Encoding
     , encodeUtf32LE
     , encodeUtf32BE
 
-#if MIN_VERSION_bytestring(0,10,4)
     -- * Encoding Text using ByteString Builders
-    -- | /Note/ that these functions are only available if built against
-    -- @bytestring >= 0.10.4.0@.
     , encodeUtf8Builder
     , encodeUtf8BuilderEscaped
-#endif
     ) where
 
 #if __GLASGOW_HASKELL__ >= 702
@@ -70,24 +66,15 @@ import Control.Monad.ST.Unsafe (unsafeIOToST, unsafeSTToIO)
 import Control.Monad.ST (unsafeIOToST, unsafeSTToIO)
 #endif
 
-#if MIN_VERSION_bytestring(0,10,4)
-import Data.Bits ((.&.))
-import Data.Text.Internal.Unsafe.Char (ord)
-import qualified Data.ByteString.Builder as B
-import qualified Data.ByteString.Builder.Internal as B hiding (empty, append)
-import qualified Data.ByteString.Builder.Prim as BP
-import qualified Data.ByteString.Builder.Prim.Internal as BP
-import qualified Data.Text.Internal.Encoding.Utf16 as U16
-#endif
-
 import Control.Exception (evaluate, try)
 import Control.Monad.ST (runST)
+import Data.Bits ((.&.))
 import Data.ByteString as B
 import Data.ByteString.Internal as B hiding (c2w)
 import Data.Text.Encoding.Error (OnDecodeError, UnicodeException, strictDecode)
 import Data.Text.Internal (Text(..), safe, text)
 import Data.Text.Internal.Private (runText)
-import Data.Text.Internal.Unsafe.Char (unsafeWrite)
+import Data.Text.Internal.Unsafe.Char (ord, unsafeWrite)
 import Data.Text.Internal.Unsafe.Shift (shiftR)
 import Data.Text.Show ()
 import Data.Text.Unsafe (unsafeDupablePerformIO)
@@ -98,8 +85,13 @@ import Foreign.Marshal.Utils (with)
 import Foreign.Ptr (Ptr, minusPtr, nullPtr, plusPtr)
 import Foreign.Storable (Storable, peek, poke)
 import GHC.Base (ByteArray#, MutableByteArray#)
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Builder.Internal as B hiding (empty, append)
+import qualified Data.ByteString.Builder.Prim as BP
+import qualified Data.ByteString.Builder.Prim.Internal as BP
 import qualified Data.Text.Array as A
 import qualified Data.Text.Internal.Encoding.Fusion as E
+import qualified Data.Text.Internal.Encoding.Utf16 as U16
 import qualified Data.Text.Internal.Fusion as F
 
 #include "text_cbits.h"
@@ -315,8 +307,6 @@ decodeUtf8' :: ByteString -> Either UnicodeException Text
 decodeUtf8' = unsafeDupablePerformIO . try . evaluate . decodeUtf8With strictDecode
 {-# INLINE decodeUtf8' #-}
 
-#if MIN_VERSION_bytestring(0,10,4)
-
 -- | Encode text to a ByteString 'B.Builder' using UTF-8 encoding.
 encodeUtf8Builder :: Text -> B.Builder
 encodeUtf8Builder = encodeUtf8BuilderEscaped (BP.liftFixedToBounded BP.word8)
@@ -377,7 +367,6 @@ encodeUtf8BuilderEscaped be =
                       outerLoop i (B.BufferRange op ope)
                   where
                     poke8 j v = poke (op `plusPtr` j) (fromIntegral v :: Word8)
-#endif
 
 -- | Encode text using UTF-8 encoding.
 encodeUtf8 :: Text -> ByteString

--- a/Data/Text/Lazy/Encoding.hs
+++ b/Data/Text/Lazy/Encoding.hs
@@ -46,27 +46,23 @@ module Data.Text.Lazy.Encoding
     , encodeUtf32LE
     , encodeUtf32BE
 
-#if MIN_VERSION_bytestring(0,10,4)
     -- * Encoding Text using ByteString Builders
     , encodeUtf8Builder
     , encodeUtf8BuilderEscaped
-#endif
     ) where
 
 import Control.Exception (evaluate, try)
+import Data.Monoid (Monoid(..))
 import Data.Text.Encoding.Error (OnDecodeError, UnicodeException, strictDecode)
 import Data.Text.Internal.Lazy (Text(..), chunk, empty, foldrChunks)
-import qualified Data.ByteString as S
-import qualified Data.ByteString.Lazy as B
-import qualified Data.ByteString.Lazy.Internal as B
-import qualified Data.ByteString.Unsafe as B
-#if MIN_VERSION_bytestring(0,10,4)
 import Data.Word (Word8)
-import Data.Monoid (Monoid(..))
+import qualified Data.ByteString as S
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Builder.Extra as B (safeStrategy, toLazyByteStringWith)
 import qualified Data.ByteString.Builder.Prim as BP
-#endif
+import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Lazy.Internal as B
+import qualified Data.ByteString.Unsafe as B
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Internal.Lazy.Encoding.Fusion as E
@@ -146,7 +142,6 @@ decodeUtf8' bs = unsafeDupablePerformIO $ do
 {-# INLINE decodeUtf8' #-}
 
 encodeUtf8 :: Text -> B.ByteString
-#if MIN_VERSION_bytestring(0,10,4)
 encodeUtf8    Empty       = B.empty
 encodeUtf8 lt@(Chunk t _) =
     B.toLazyByteStringWith strategy B.empty $ encodeUtf8Builder lt
@@ -167,11 +162,6 @@ encodeUtf8Builder =
 encodeUtf8BuilderEscaped :: BP.BoundedPrim Word8 -> Text -> B.Builder
 encodeUtf8BuilderEscaped prim =
     foldrChunks (\c b -> TE.encodeUtf8BuilderEscaped prim c `mappend` b) mempty
-
-#else
-encodeUtf8 (Chunk c cs) = B.Chunk (TE.encodeUtf8 c) (encodeUtf8 cs)
-encodeUtf8 Empty        = B.Empty
-#endif
 
 -- | Decode text from little endian UTF-16 encoding.
 decodeUtf16LEWith :: OnDecodeError -> B.ByteString -> Text

--- a/benchmarks/text-benchmarks.cabal
+++ b/benchmarks/text-benchmarks.cabal
@@ -15,6 +15,11 @@ build-type:          Simple
 
 cabal-version:       >=1.2
 
+flag bytestring-builder
+  description: Depend on the bytestring-builder package for backwards compatibility.
+  default: False
+  manual: False
+
 flag llvm
   description: use LLVM
   default: False
@@ -33,7 +38,6 @@ executable text-benchmarks
   build-depends:  base == 4.*,
                   binary,
                   blaze-builder,
-                  bytestring,
                   bytestring-lexing >= 0.5.0,
                   containers,
                   criterion >= 0.10.0.0,
@@ -45,6 +49,12 @@ executable text-benchmarks
                   stringsearch,
                   utf8-string,
                   vector
+
+  if flag(bytestring-builder)
+    build-depends: bytestring         >= 0.9    && < 0.10.4,
+                   bytestring-builder >= 0.10.4
+  else
+    build-depends: bytestring         >= 0.10.4
 
 executable text-multilang
   hs-source-dirs: haskell

--- a/tests/literal-rule-test.sh
+++ b/tests/literal-rule-test.sh
@@ -6,7 +6,7 @@ function check_firings() {
     rule=$1
     expected=$2
     build="ghc -O -ddump-rule-firings LiteralRuleTest.hs"
-    build="$build -i.. -I../include -DMIN_VERSION_bytestring(a,b,c)=1"
+    build="$build -i.. -I../include"
     touch LiteralRuleTest.hs
     echo -n "Want to see $expected firings of rule $rule... " >&2
     firings=$($build 2>&1 | grep "Rule fired: $rule\$" | wc -l)

--- a/text.cabal
+++ b/text.cabal
@@ -64,6 +64,11 @@ extra-source-files:
     tests/scripts/*.sh
     tests/text-tests.cabal
 
+flag bytestring-builder
+  description: Depend on the bytestring-builder package for backwards compatibility.
+  default: False
+  manual: False
+
 flag developer
   description: operate in developer mode
   default: False
@@ -133,10 +138,11 @@ library
     deepseq    >= 1.1.0.0,
     ghc-prim   >= 0.2
 
-  if impl(ghc >= 7.7)
-    build-depends: bytestring >= 0.10.4.0
+  if flag(bytestring-builder)
+    build-depends: bytestring         >= 0.9    && < 0.10.4,
+                   bytestring-builder >= 0.10.4
   else
-    build-depends: bytestring >= 0.9
+    build-depends: bytestring         >= 0.10.4
 
   cpp-options: -DHAVE_DEEPSEQ
   ghc-options: -Wall -fwarn-tabs -funbox-strict-fields -O2
@@ -171,7 +177,6 @@ test-suite tests
     array,
     base,
     binary,
-    bytestring,
     deepseq,
     directory,
     ghc-prim,
@@ -180,6 +185,12 @@ test-suite tests
     test-framework >= 0.4,
     test-framework-hunit >= 0.2,
     test-framework-quickcheck2 >= 0.2
+
+  if flag(bytestring-builder)
+    build-depends: bytestring         >= 0.9    && < 0.10.4,
+                   bytestring-builder >= 0.10.4
+  else
+    build-depends: bytestring         >= 0.10.4
 
   if flag(integer-simple)
     cpp-options: -DINTEGER_SIMPLE


### PR DESCRIPTION
This was previously proposed in #67, which was ultimately rejected due to concerns about requiring the use of `bytestring-builder` in a Haskell Platform release that shipped GHC 7.8. That Haskell Platform has since been released, so I don't think it's a concern anymore.

This PR ensures that `encodeUtf8Builder` is always defined, even on older versions of GHC, by depending on the `bytestring-builder` package if a particularly old version of `bytestring` is being used. This dependency shouldn't be a concern going forward, since even if, say, `text` were to become a GHC dependency, building `text` as part of the GHC build process wouldn't incur a `bytestring-builder` dependency.

A real-world example of where this would be useful is in https://github.com/bos/aeson/pull/426#issuecomment-225358139, where we had to work around the fact that `text` doesn't export `encodeUtf8Builder` when `text` is built against an old version of `bytestring`.

/cc @lpsmith