### PR TITLE
Fix documentation for  Data.Text.Read hexadecimal

### DIFF
--- a/Data/Text/Lazy/Read.hs
+++ b/Data/Text/Lazy/Read.hs
@@ -68,9 +68,9 @@ decimal txt
         go n d = (n * 10 + fromIntegral (digitToInt d))
 
 -- | Read a hexadecimal integer, consisting of an optional leading
--- @\"0x\"@ followed by at least one decimal digit. Input is consumed
--- until a non-hex-digit or end of string is reached.  This function
--- is case insensitive.
+-- @\"0x\"@ followed by at least one hexadecimal digit. Input is
+-- consumed until a non-hex-digit or end of string is reached.
+-- This function is case insensitive.
 --
 -- This function does not handle leading sign characters.  If you need
 -- to handle signed input, use @'signed' 'hexadecimal'@.

--- a/Data/Text/Read.hs
+++ b/Data/Text/Read.hs
@@ -67,9 +67,9 @@ decimal txt
         go n d = (n * 10 + fromIntegral (digitToInt d))
 
 -- | Read a hexadecimal integer, consisting of an optional leading
--- @\"0x\"@ followed by at least one decimal digit. Input is consumed
--- until a non-hex-digit or end of string is reached.  This function
--- is case insensitive.
+-- @\"0x\"@ followed by at least one hexadecimal digit. Input is
+-- consumed until a non-hex-digit or end of string is reached.
+-- This function is case insensitive.
 --
 -- This function does not handle leading sign characters.  If you need
 -- to handle signed input, use @'signed' 'hexadecimal'@.


### PR DESCRIPTION
Embarrassingly trivial PR here... docs were saying decimal digit instead of hexadecimal digit.
