### PR TITLE
Improvements to `toTitle` functionality

### DIFF
--- a/Data/Text/Internal/Fusion/Common.hs
+++ b/Data/Text/Internal/Fusion/Common.hs
@@ -107,7 +107,7 @@ import Prelude (Bool(..), Char, Eq(..), Int, Integral, Maybe(..),
 import qualified Data.List as L
 import qualified Prelude as P
 import Data.Bits (shiftL)
-import Data.Char (isLetter)
+import Data.Char (isLetter, isSpace)
 import Data.Int (Int64)
 import Data.Text.Internal.Fusion.Types
 import Data.Text.Internal.Fusion.CaseMapping (foldMapping, lowerMapping, titleMapping,
@@ -462,15 +462,16 @@ toTitle (Stream next0 s0 len) = Stream next (CC (False :*: s0) '\0' '\0') len
   where
     next (CC (letter :*: s) '\0' _) =
       case next0 s of
-        Done           -> Done
-        Skip s'        -> Skip (CC (letter :*: s') '\0' '\0')
+        Done            -> Done
+        Skip s'         -> Skip (CC (letter :*: s') '\0' '\0')
         Yield c s'
-          | letter'    -> if letter
-                          then lowerMapping c (letter' :*: s')
-                          else titleMapping c (letter' :*: s')
-          | otherwise  -> Yield c (CC (letter' :*: s') '\0' '\0')
-          where letter' = isLetter c
-    next (CC s a b)     = Yield a (CC s b '\0')
+          | nonSpace    -> if letter
+                           then lowerMapping c (nonSpace :*: s')
+                           else titleMapping c (letter' :*: s')
+          | otherwise   -> Yield c (CC (letter' :*: s') '\0' '\0')
+          where nonSpace = P.not (isSpace c)
+                letter'  = isLetter c
+    next (CC s a b)      = Yield a (CC s b '\0')
 {-# INLINE [0] toTitle #-}
 
 data Justify i s = Just1 !i !s

--- a/tests/Tests/Properties.hs
+++ b/tests/Tests/Properties.hs
@@ -326,6 +326,8 @@ t_toUpper_upper t = p (T.toUpper t) >= p t
     where p = T.length . T.filter isUpper
 tl_toUpper_upper t = p (TL.toUpper t) >= p t
     where p = TL.length . TL.filter isUpper
+t_toTitle_title t = all (<= 1) (caps t)
+    where caps = fmap (T.length . T.filter isUpper) . T.words . T.toTitle
 
 justifyLeft k c xs  = xs ++ L.replicate (k - length xs) c
 justifyRight m n xs = L.replicate (m - length xs) n ++ xs
@@ -1030,7 +1032,8 @@ tests =
         testProperty "tl_toLower_lower" tl_toLower_lower,
         testProperty "t_toUpper_length" t_toUpper_length,
         testProperty "t_toUpper_upper" t_toUpper_upper,
-        testProperty "tl_toUpper_upper" tl_toUpper_upper
+        testProperty "tl_toUpper_upper" tl_toUpper_upper,
+        testProperty "t_toTitle_title" t_toTitle_title
       ],
 
       testGroup "justification" [


### PR DESCRIPTION
Function now correctly deals with apostrophes, etc. For example, the “s” in “it’s”, should not be transformed to upper.