### PR TITLE
Add `unsnoc` to Data.Text and Data.Text.Lazy

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -60,6 +60,7 @@ module Data.Text
     , snoc
     , append
     , uncons
+    , unsnoc
     , head
     , last
     , tail
@@ -544,6 +545,17 @@ init (Text arr off len) | len <= 0                   = emptyError "init"
 "TEXT init -> unfused" [1] forall t.
     unstream (S.init (stream t)) = init t
  #-}
+
+-- | /O(1)/ Returns all but the last character and the last character of a
+-- 'Text', or 'Nothing' if empty.
+unsnoc :: Text -> Maybe (Text, Char)
+unsnoc (Text arr off len)
+    | len <= 0                 = Nothing
+    | n < 0xDC00 || n > 0xDFFF = Just (text arr off (len-1), unsafeChr n)
+    | otherwise                = Just (text arr off (len-2), U16.chr2 n0 n)
+    where n  = A.unsafeIndex arr (off+len-1)
+          n0 = A.unsafeIndex arr (off+len-2)
+{-# INLINE [1] unsnoc #-}
 
 -- | /O(1)/ Tests whether a 'Text' is empty or not.  Subject to
 -- fusion.

--- a/Data/Text/Lazy.hs
+++ b/Data/Text/Lazy.hs
@@ -68,6 +68,7 @@ module Data.Text.Lazy
     , snoc
     , append
     , uncons
+    , unsnoc
     , head
     , last
     , tail
@@ -560,6 +561,15 @@ init Empty = emptyError "init"
 "LAZY TEXT init -> unfused" [1] forall t.
     unstream (S.init (stream t)) = init t
  #-}
+
+-- | /O(n\/c)/ Returns the 'init' and 'last' of a 'Text', or 'Nothing' if
+-- empty.
+--
+-- * It is no faster than using 'init' and 'last'.
+unsnoc :: Text -> Maybe (Text, Char)
+unsnoc Empty          = Nothing
+unsnoc ts@(Chunk _ _) = Just (init ts, last ts)
+{-# INLINE unsnoc #-}
 
 -- | /O(1)/ Tests whether a 'Text' is empty or not.  Subject to
 -- fusion.

--- a/tests/Tests/Properties.hs
+++ b/tests/Tests/Properties.hs
@@ -9,7 +9,7 @@ module Tests.Properties
     ) where
 
 import Control.Applicative ((<$>), (<*>))
-import Control.Arrow ((***), second)
+import Control.Arrow ((***), first, second)
 import Data.Bits ((.&.))
 import Data.Char (chr, isDigit, isHexDigit, isLower, isSpace, isLetter, isUpper, ord)
 import Data.Int (Int8, Int16, Int32, Int64)
@@ -230,6 +230,13 @@ sf_uncons p       = (uncons . L.filter p) `eqP`
                     (fmap (second unpackS) . S.uncons . S.filter p)
 t_uncons          = uncons   `eqP` (fmap (second unpackS) . T.uncons)
 tl_uncons         = uncons   `eqP` (fmap (second unpackS) . TL.uncons)
+
+unsnoc xs@(_:_) = Just (init xs, last xs)
+unsnoc []       = Nothing
+
+t_unsnoc          = unsnoc   `eqP` (fmap (first unpackS) . T.unsnoc)
+tl_unsnoc         = unsnoc   `eqP` (fmap (first unpackS) . TL.unsnoc)
+
 s_head            = head   `eqP` S.head
 sf_head p         = (head . L.filter p) `eqP` (S.head . S.filter p)
 t_head            = head   `eqP` T.head
@@ -976,6 +983,8 @@ tests =
       testProperty "sf_uncons" sf_uncons,
       testProperty "t_uncons" t_uncons,
       testProperty "tl_uncons" tl_uncons,
+      testProperty "t_unsnoc" t_unsnoc,
+      testProperty "tl_unsnoc" tl_unsnoc,
       testProperty "s_head" s_head,
       testProperty "sf_head" sf_head,
       testProperty "t_head" t_head,


### PR DESCRIPTION
Closes #171.

(I don't understand the streaming/fusion side of things well enough to add them, or the inline stages well enough to set a good level, unfortunately. The simple but probably suboptimal Lazy unsnoc is more or less copied from ByteString; I think it makes sense because the operation is inherently slow and you'd probably avoid it in performance-sensitive code anyway.)