### PR TITLE
fix takeEnd and dropEnd - issue #176

### DIFF
--- a/Data/Text.hs
+++ b/Data/Text.hs
@@ -1099,8 +1099,8 @@ takeEnd n t@(Text arr off len)
 iterNEnd :: Int -> Text -> Int
 iterNEnd n t@(Text _arr _off len) = loop (len-1) n
   where loop i !m
+          | m <= 0    = i+1
           | i <= 0    = 0
-          | m <= 1    = i
           | otherwise = loop (i+d) (m-1)
           where d = reverseIter_ t i
 


### PR DESCRIPTION
see #176 

a separate issue is that Data.Text is not tested with non-ascii chars
to test this diff i created 

```
newtype MyString = MyString String deriving Show

instance Arbitrary MyString where
  arbitrary = MyString <$> oneof [listOf (chr `fmap` oneof [choose (0,127), choose (65536, 1114111)])]
  shrink (MyString s) = map MyString $ shrink s
```

and used it to generate random strings...
the `t_takeEnd` test showed broken with this change and this diff fixed it